### PR TITLE
verziószámok frissítése a README.adoc-ban

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,11 +54,11 @@ Tehát a következő telepítési "másoló" scriptet lehet használni:
 [source,bash]
 ----
 # sample-rest-service esetében
-docker cp local_path/sample/sample-rest-service/target/sample-rest-service-0.1.0-SNAPSHOT.war bs-sample-service:/opt/jboss/wildfly/standalone/deployments/ROOT.war
+docker cp local_path/sample/sample-rest-service/target/sample-rest-service-2.0.0-SNAPSHOT.war bs-sample-service:/opt/jboss/wildfly/standalone/deployments/ROOT.war
 # sample-jpa-service esetében
-docker cp local_path/sample/sample-jpa-service/target/sample-jpa-service-0.1.0-SNAPSHOT.war bs-sample-service:/opt/jboss/wildfly/standalone/deployments/ROOT.war
+docker cp local_path/sample/sample-jpa-service/target/sample-jpa-service-2.0.0-SNAPSHOT.war bs-sample-service:/opt/jboss/wildfly/standalone/deployments/ROOT.war
 # sample-mongo-service esetében
-docker cp local_path/sample/sample-mongo-service/target/sample-mongo-service-0.1.0-SNAPSHOT.war bs-sample-service:/opt/jboss/wildfly/standalone/deployments/ROOT.war
+docker cp local_path/sample/sample-mongo-service/target/sample-mongo-service-2.0.0-SNAPSHOT.war bs-sample-service:/opt/jboss/wildfly/standalone/deployments/ROOT.war
 ----
 De kényelmesebben az Ant segítségével 1 kattintással az IDEből,
 például a `sample/sample-rest-service/build.xml` ant fájl


### PR DESCRIPTION
Nem találtam más, igazán jó megoldást arra, hogy a verziószám automatikusan frissüljön a README-ben, ezért manuálisan frissítettem a verziószámokat.

Esetleg a példa kódokban lehetne használni a tényleges verziószám helyett valami placeholder-t, például <PROJECT_VERSION> és a kódblokk alatt jelezni, hogy ehelyére a valódi verziószámot be kell illeszteni a parancs megfuttatása előtt. Így nem kell ezt mindig manuálisan frissíteni verzióemeléskor.